### PR TITLE
Handle v2.0.0 issue in pytorch-lightning < v2.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [unreleased](https://github.com/convml/convml-tt/tree/HEAD)
+
+*maintenance*
+
+- Handle pytorch-lightning < 2.3.2 issue with numpy v2.0.0 by pinning to numpy<2.0.0
+  [\#87](https://github.com/convml/convml-tt/pull/87)
+
+
 ## [v0.14.1](https://github.com/convml/convml_tt/tree/v0.14.1)
 
 [Full Changelog](https://github.com/convml/convml_tt/compare/v0.14.1...v0.14.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 *maintenance*
 
-- Handle pytorch-lightning < 2.3.2 issue with numpy v2.0.0 by pinning to numpy<2.0.0
+- Handle pytorch-lightning < 2.1.0 issue with numpy v2.0.0 by pinning to numpy<2.0.0
   [\#87](https://github.com/convml/convml-tt/pull/87)
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ install_requires =
     torchvision >= 0.4.0
     semver
     statsmodels
+    numpy < 2.0.0  # pytorch-lightning < 2.0.0 uses np.Inf which has been removed in v2.0.0
 setup_requires =
     setuptools >= 40.4
     setuptools_scm

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ install_requires =
     torchvision >= 0.4.0
     semver
     statsmodels
-    numpy < 2.0.0  # pytorch-lightning < 2.0.0 uses np.Inf which has been removed in v2.0.0
+    numpy < 2.0.0  # pytorch-lightning < 2.1.0 uses np.Inf which has been removed in v2.0.0
 setup_requires =
     setuptools >= 40.4
     setuptools_scm


### PR DESCRIPTION
Prior to pytorch-lightning 2.3.2 (we use < 2.0.0) the pytorch-lightning package made use of `numpy.Inf` but that was removed (renamed `numpy.inf`) in numpy v2.0.0